### PR TITLE
fixed CI job problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.0</version>
-        <relativePath/>
-    </parent>
+    <name>Code Snippet Manager</name>
+    <description>A simple light-weight Java tool that helps in managing code snippets</description>
+    <url>https://github.com/gufranthakur/Code-Snippet-Manager</url>
 
     <groupId>org.example</groupId>
     <artifactId>CodeSnippetManager</artifactId>
@@ -22,8 +19,53 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.0</version>
+        <relativePath/>
+    </parent>
+
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>package.json</include>
+                </includes>
+                <filtering>true</filtering>
+                <targetPath>${project.basedir}</targetPath>
+            </resource>
+        </resources>
         <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-and-filter-package-json</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources</directory>
+                                    <includes>
+                                        <include>package.json</include>
+                                    </includes>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                            <delimiters>
+                                <delimiter>@</delimiter>
+                            </delimiters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/resources/package.json
+++ b/src/main/resources/package.json
@@ -1,11 +1,11 @@
 {
     "bin": {"code-snippet-manager": "jdeploy-bundle/jdeploy.js"},
     "author": "Gufran Thakur",
-    "description": "A simple light-weight Java tool that helps in managing code snippets",
+    "description": "@project.description@",
     "main": "index.js",
     "preferGlobal": true,
     "repository": "",
-    "version": "1.0.0",
+    "version": "@project.version@",
     "jdeploy": {
         "jdk": false,
         "buildCommand": [
@@ -18,9 +18,9 @@
             "url": "code-snippet-manager"
         }],
         "javaVersion": "21",
-        "jar": "target/CodeSnippetManager-1.0-SNAPSHOT.jar",
+        "jar": "target/@project.artifactId@-@project.version@.jar",
         "javafx": false,
-        "title": "Code Snippet Manager"
+        "title": "@project.name@"
     },
     "dependencies": {
         "command-exists-promise": "^2.0.2",


### PR DESCRIPTION
Now package.json is being relocated by maven and pulls name, version, description from pom.xml programmatically, so CI jobs will no longer fail due to mismatched versions. I have also personally run [the CI job and verified it completes](https://github.com/justADeni/Code-Snippet-Manager/actions/runs/14905754287). Sorry for breaking the CI with my last PR, it won't happen again 😄 